### PR TITLE
fix: loading pricing in signed out state

### DIFF
--- a/src/migrator-management-canister-frontend/src/components/LandingPage/LandingPage.tsx
+++ b/src/migrator-management-canister-frontend/src/components/LandingPage/LandingPage.tsx
@@ -21,7 +21,7 @@ function LandingPage() {
   const handleLaunchApp = () => {
     navigate("/dashboard");
   };
-  const { tiers } = usePricing();
+  const { tiers, preset_tiers } = usePricing();
 
   useEffect(() => {
     // Mouse trail effect
@@ -363,11 +363,12 @@ function LandingPage() {
       >
         <h2 id="pricing-heading">Pricing</h2>
         <div>
-          {tiers ? (
+          {tiers || preset_tiers ? (
             <NonSubbed
               hideButtons={true}
               subscription={null}
-              tiers={tiers}
+              tiers={preset_tiers}
+              // tiers={tiers ? tiers : preset_tiers}
               handleSelectPlan={() => {}}
               pricingState={[false, () => {}]}
             />

--- a/src/migrator-management-canister-frontend/src/context/PricingContext/PricingContext.tsx
+++ b/src/migrator-management-canister-frontend/src/context/PricingContext/PricingContext.tsx
@@ -6,6 +6,7 @@ import { useIdentity } from "../IdentityContext/IdentityContext";
 import { useQuery } from "@tanstack/react-query";
 import { sanitizeObject } from "../../utility/sanitize";
 import { useHttpAgent } from "../HttpAgentContext/HttpAgentContext";
+import { preset_tiers } from "./tiers";
 
 export interface TierListData {
   id: number;
@@ -29,6 +30,7 @@ export interface SubscriptionData {
 interface PricingContextType {
   tiers: Tier[] | null;
   isLoadingTiers: boolean;
+  preset_tiers: Tier[];
 }
 
 export const PricingContext = createContext<PricingContextType | undefined>(
@@ -111,6 +113,7 @@ export function PricingProvider({ children }: { children: ReactNode }) {
       value={{
         tiers,
         isLoadingTiers,
+        preset_tiers: preset_tiers,
       }}
     >
       {children}

--- a/src/migrator-management-canister-frontend/src/context/PricingContext/tiers.ts
+++ b/src/migrator-management-canister-frontend/src/context/PricingContext/tiers.ts
@@ -1,0 +1,62 @@
+export const preset_tiers = [
+    {
+        id: BigInt(0),
+        name: "Basic",
+        slots: BigInt(1),
+        min_deposit: {
+            e8s: BigInt(50_000_000),
+        },
+        price: { e8s: BigInt(0) }, // Free tier
+        features: [
+            "1 Canister",
+            "Basic Support",
+            "Manual Deployments",
+            "GitHub Integration",
+        ],
+    },
+    {
+        id: BigInt(1),
+        name: "Pro",
+        slots: BigInt(5),
+        min_deposit: { e8s: BigInt(200_000_000) }, // 2 ICP
+        price: { e8s: BigInt(500_000_000) }, // 5 ICP
+        features: [
+            "5 Canisters",
+            "Priority Support",
+            "Automated Deployments",
+            "Custom Domains",
+            "Deployment History",
+            "Advanced Analytics",
+        ],
+    },
+    {
+        id: BigInt(2),
+        name: "Enterprise",
+        slots: BigInt(25),
+        min_deposit: { e8s: BigInt(500_000_000) }, // 5 ICP
+        price: { e8s: BigInt(2_500_000_000) }, // 25 ICP
+        features: [
+            "25 Canisters",
+            "24/7 Support",
+            "Team Management",
+            "Advanced Analytics",
+            "Priority Queue",
+            "Custom Branding",
+            "API Access",
+        ],
+    },
+    {
+        id: BigInt(3),
+        name: "Freemium",
+        slots: BigInt(1),
+        min_deposit: { e8s: BigInt(0) },
+        price: { e8s: BigInt(0) }, // Free tier
+        features: [
+            "1 Canister",
+            "Manual Deployments",
+            "GitHub Integration",
+            "4hrs Demo Hosting Trial",
+            "3 Free Trials per day",
+        ],
+    },
+]


### PR DESCRIPTION
**Reason for Change**

The pricing section of the landing page is not loading since it is trying to fetch the pricing tiers from the canister.

**Solution**
Quick fix by creating a hardcoded preset tiers list and use it as fallback to display the pricing list.

**Note**
Actual fix requires working around the identity provider to use the anonymous principal to do such method calls to the backend canister when not authenticated